### PR TITLE
Define constants for standard tags and log fields

### DIFF
--- a/OpenTracing/OpenTracing.xcodeproj/project.pbxproj
+++ b/OpenTracing/OpenTracing.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		61BA34F12424F16C00587A96 /* Span.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BA34EA2424F16C00587A96 /* Span.swift */; };
 		61BA34F22424F16C00587A96 /* SpanContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BA34EB2424F16C00587A96 /* SpanContext.swift */; };
 		61BA34F32424F16C00587A96 /* Tracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BA34EC2424F16C00587A96 /* Tracer.swift */; };
+		61F1A61D2499108100075390 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A61C2499108100075390 /* Constants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		61BA34EA2424F16C00587A96 /* Span.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Span.swift; sourceTree = "<group>"; };
 		61BA34EB2424F16C00587A96 /* SpanContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanContext.swift; sourceTree = "<group>"; };
 		61BA34EC2424F16C00587A96 /* Tracer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tracer.swift; sourceTree = "<group>"; };
+		61F1A61C2499108100075390 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +79,7 @@
 				61BA34EA2424F16C00587A96 /* Span.swift */,
 				61BA34EB2424F16C00587A96 /* SpanContext.swift */,
 				61BA34EC2424F16C00587A96 /* Tracer.swift */,
+				61F1A61C2499108100075390 /* Constants.swift */,
 			);
 			name = OpenTracing;
 			path = ../../Sources/OpenTracing;
@@ -168,6 +171,7 @@
 				61BA34F12424F16C00587A96 /* Span.swift in Sources */,
 				61BA34ED2424F16C00587A96 /* Format.swift in Sources */,
 				61BA34F22424F16C00587A96 /* SpanContext.swift in Sources */,
+				61F1A61D2499108100075390 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/OpenTracing/Constants.swift
+++ b/Sources/OpenTracing/Constants.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A collection of standard `Span` tag keys defined by Open Tracing.
+/// Use them as the `key` in `span.setTag(key:value:)`. Use the expected type for the `value`.
+///
+/// See more: [Span tags table](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table)
+///
+public struct OTTags {
+
+    /// Expected value: `String`.
+    public static let component = "component"
+
+    /// Expected value: `String`
+    public static let dbInstance = "db.instance"
+
+    /// Expected value: `String`
+    public static let dbStatement = "db.statement"
+
+    /// Expected value: `String`
+    public static let dbType = "db.type"
+
+    /// Expected value: `String`
+    public static let dbUser = "db.user"
+
+    /// Expected value: `Bool`
+    public static let error = "error"
+
+    /// Expected value: `String`
+    public static let httpMethod = "http.method"
+
+    /// Expected value: `Int`
+    public static let httpStatusCode = "http.status_code"
+
+    /// Expected value: `String`
+    public static let httpUrl = "http.url"
+
+    /// Expected value: `String`
+    public static let messageBusDestination = "message_bus.destination"
+
+    /// Expected value: `String`
+    public static let peerAddress = "peer.address"
+
+    /// Expected value: `String`
+    public static let peerHostname = "peer.hostname"
+
+    /// Expected value: `String`
+    public static let peerIPv4 = "peer.ipv4"
+
+    /// Expected value: `String`
+    public static let peerIPv6 = "peer.ipv6"
+
+    /// Expected value: `Int`
+    public static let peerPort = "peer.port"
+
+    /// Expected value: `String`
+    public static let peerService = "peer.service"
+
+    /// Expected value: `Int`
+    public static let samplingPriority = "sampling.priority"
+
+    /// Expected value: `String`
+    public static let spanKind = "span.kind"
+}
+
+/// A collection of standard `Span` log fields defined by Open Tracing.
+/// Use them as the `key` for `fields` dictionary in `span.log(fields:)`. Use the expected type for the value.
+///
+/// See more: [Log fields table](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table)
+///
+public struct OTLogFields {
+
+    /// Expected value: `String`
+    public static let errorKind = "error.kind"
+
+    /// Expected value: `String`
+    public static let event = "event"
+
+    /// Expected value: `String`
+    public static let message = "message"
+
+    /// Expected value: `String`
+    public static let stack = "stack"
+}


### PR DESCRIPTION
📦 The Open Tracing standard defines two sets of constants: [span tags](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table) and [log fields](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table).

#### Standard Span Tags

They are meant to be used as the `key` value in:
```swift
// OpenTracing.Span

func setTag(key: String, value: Codable)
```

#### Standard Log Fields

They are meant to be used as the `key` value for `fields` dictionary in:
```swift
// OpenTracing.Span

func log(fields: [String: Codable], timestamp: Date)
```

This PR adds public definition of all tags and fields defined by Open Tracing specification.